### PR TITLE
Fix stale-screensaver caching + slimmer LCD logo windows

### DIFF
--- a/build/build.mjs
+++ b/build/build.mjs
@@ -406,7 +406,15 @@ function versionAssets(html, version) {
     );
 }
 
-/** Short content hash of all CSS + JS, used as the asset cache-busting version. */
+// Standalone pages that carry their own inline behaviour (not just a reference to
+// a versioned /scripts file). They must feed the version hash too, otherwise a
+// change to one of them leaves VERSION unchanged, the service worker never
+// reinstalls, and the old cached copy keeps being served (e.g. the screensaver
+// showing a previous version after a deploy). These files carry no ?v= stamp of
+// their own, so hashing them is stable (no chicken-and-egg with the version).
+const VERSIONED_PAGES = ['screensaver/index.html'];
+
+/** Short content hash of all CSS + JS (+ inline-logic pages), the cache-busting version. */
 async function computeAssetVersion(rootDir) {
     const dirs = ['styles', 'scripts'];
     const parts = [];
@@ -420,6 +428,9 @@ async function computeAssetVersion(rootDir) {
             }
         };
         try { await walk(base); } catch { /* dir may not exist */ }
+    }
+    for (const rel of VERSIONED_PAGES) {
+        try { parts.push(await fs.readFile(path.join(rootDir, rel))); } catch { /* optional */ }
     }
     return crypto.createHash('sha256').update(Buffer.concat(parts)).digest('hex').slice(0, 8);
 }

--- a/index.html
+++ b/index.html
@@ -4,13 +4,13 @@
     <link id="dynamic-favicon" rel="icon" href="/logo/favicon.svg">
     <link rel="manifest" href="/manifest.json">
     <link rel="preload" href="/styles/fonts/FrankRuhl.ttf" as="font" type="font/ttf" crossorigin>
-    <script src="/scripts/theme-loader.js?v=5869e14a"></script>
+    <script src="/scripts/theme-loader.js?v=781ca0b6"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="translation-source" content="index">
     <meta name="eink-compatibility" content="optimized"> 
     <title>Pelmeniboiler</title>
-    <link rel="stylesheet" href="styles/pelmeni2025.css?v=5869e14a">
+    <link rel="stylesheet" href="styles/pelmeni2025.css?v=781ca0b6">
     <!-- RSS Links for RSS Readers-->
     <link rel="alternate" type="application/rss+xml" title="English RSS Feed" href="https://pelmeniboiler.github.io/rss/en/feed.xml">
     <link rel="alternate" type="application/rss+xml" title="Japanese RSS Feed" href="https://pelmeniboiler.github.io/rss/ja/feed.xml">
@@ -151,10 +151,10 @@
     <div id="settings-module-placeholder"></div>
     <div id="start-menu-module-placeholder"></div>
 
-    <script src="scripts/blog-loader.js?v=5869e14a" defer></script>
-    <script src="scripts/module-loader.js?v=5869e14a" defer></script>
-    <script src="scripts/notify-bell.js?v=5869e14a" defer></script>
-    <script src="scripts/logo-pong.js?v=5869e14a" defer></script>
+    <script src="scripts/blog-loader.js?v=781ca0b6" defer></script>
+    <script src="scripts/module-loader.js?v=781ca0b6" defer></script>
+    <script src="scripts/notify-bell.js?v=781ca0b6" defer></script>
+    <script src="scripts/logo-pong.js?v=781ca0b6" defer></script>
     
 </body>
 </html>

--- a/screensaver/index.html
+++ b/screensaver/index.html
@@ -14,12 +14,13 @@
             font-family: var(--font-body, serif); font-size: 12px; color: var(--text-color); opacity: 0.5;
             letter-spacing: 1px; user-select: none; }
 
-        /* --- LCD: 25 logo.canvas windows bouncing around --- */
+        /* --- LCD: 25 logo.canvas windows bouncing around (kept compact/square) --- */
         #lcd-field { position: fixed; inset: 0; }
-        .ss-logo { position: fixed; top: 0; left: 0; width: 132px; will-change: transform; }
-        .ss-logo .title-bar { height: 22px; font-size: 12px; }
-        .ss-logo-body { padding: 8px; display: flex; justify-content: center; }
-        .ss-logo-body img { width: 62px; height: 62px; }
+        .ss-logo { position: fixed; top: 0; left: 0; width: 88px; will-change: transform; }
+        .ss-logo .title-bar { height: 18px; font-size: 9px; padding: 0 4px; }
+        .ss-logo .title-bar .title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .ss-logo-body { padding: 7px; display: flex; justify-content: center; }
+        .ss-logo-body img { width: 58px; height: 58px; }
 
         /* --- E-INK: a random photo from a photo article, redrawn as a halftone
                mosaic built out of the ShZh logo (ink on background). --- */

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 // with the same content hash used for ?v= asset cache-busting, so every deploy
 // that changes an asset also retires the old cache.
 
-const VERSION = '5869e14a';
+const VERSION = '781ca0b6';
 const CACHE = `pelmeniboiler-${VERSION}`;
 
 // The minimal shell needed to render pages offline. Everything else (articles,


### PR DESCRIPTION
Follow-up to #14 (already merged).

## Why the screensaver kept showing the old version
The deploy was fine — the live `/screensaver/` already has the new photo-halftone code. The problem was **client caching**: the service worker's `VERSION` is a content hash of `styles/` + `scripts/` only. The screensaver's behaviour lives *inline* in `screensaver/index.html`, so a screensaver-only change left `VERSION` unchanged. An unchanged `sw.js` means the browser never reinstalls the worker, `activate` never runs, and the old cache (holding the previous screensaver HTML) is never purged.

**Fix:** `computeAssetVersion` now also hashes a small list of inline-logic pages (`screensaver/index.html`). Any change to one bumps `VERSION`, so the old cache is retired like any other asset change. This deploy bumps `VERSION` `5869e14a → 781ca0b6`, which will force every browser to reinstall the worker and drop the stale screensaver on next visit.

## Slimmer LCD logo windows
The 25 bouncing `logo.canvas` windows were too wide/landscape. Now compact and near-square: narrower frame (132px → 88px), tighter title bar, ellipsis on the title.

Test suite: **55 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDXeeJN8X7cF8LKYzB54qM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDXeeJN8X7cF8LKYzB54qM)_