### PR TITLE
Screensaver LCD: use the real logo.canvas window (fixes black-svg logo)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,13 +4,13 @@
     <link id="dynamic-favicon" rel="icon" href="/logo/favicon.svg">
     <link rel="manifest" href="/manifest.json">
     <link rel="preload" href="/styles/fonts/FrankRuhl.ttf" as="font" type="font/ttf" crossorigin>
-    <script src="/scripts/theme-loader.js?v=781ca0b6"></script>
+    <script src="/scripts/theme-loader.js?v=3bb0d26c"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="translation-source" content="index">
     <meta name="eink-compatibility" content="optimized"> 
     <title>Pelmeniboiler</title>
-    <link rel="stylesheet" href="styles/pelmeni2025.css?v=781ca0b6">
+    <link rel="stylesheet" href="styles/pelmeni2025.css?v=3bb0d26c">
     <!-- RSS Links for RSS Readers-->
     <link rel="alternate" type="application/rss+xml" title="English RSS Feed" href="https://pelmeniboiler.github.io/rss/en/feed.xml">
     <link rel="alternate" type="application/rss+xml" title="Japanese RSS Feed" href="https://pelmeniboiler.github.io/rss/ja/feed.xml">
@@ -151,10 +151,10 @@
     <div id="settings-module-placeholder"></div>
     <div id="start-menu-module-placeholder"></div>
 
-    <script src="scripts/blog-loader.js?v=781ca0b6" defer></script>
-    <script src="scripts/module-loader.js?v=781ca0b6" defer></script>
-    <script src="scripts/notify-bell.js?v=781ca0b6" defer></script>
-    <script src="scripts/logo-pong.js?v=781ca0b6" defer></script>
+    <script src="scripts/blog-loader.js?v=3bb0d26c" defer></script>
+    <script src="scripts/module-loader.js?v=3bb0d26c" defer></script>
+    <script src="scripts/notify-bell.js?v=3bb0d26c" defer></script>
+    <script src="scripts/logo-pong.js?v=3bb0d26c" defer></script>
     
 </body>
 </html>

--- a/screensaver/index.html
+++ b/screensaver/index.html
@@ -14,13 +14,13 @@
             font-family: var(--font-body, serif); font-size: 12px; color: var(--text-color); opacity: 0.5;
             letter-spacing: 1px; user-select: none; }
 
-        /* --- LCD: 25 logo.canvas windows bouncing around (kept compact/square) --- */
+        /* --- LCD: 25 logo.canvas windows bouncing around. These are the real
+               logo.canvas window (same markup + classes), so the shared
+               .window / .title-bar / .logo-image-container rules style them
+               identically — including the ShZh mark in the theme's text colour.
+               .ss-logo only takes over positioning for the bounce. --- */
         #lcd-field { position: fixed; inset: 0; }
-        .ss-logo { position: fixed; top: 0; left: 0; width: 88px; will-change: transform; }
-        .ss-logo .title-bar { height: 18px; font-size: 9px; padding: 0 4px; }
-        .ss-logo .title-bar .title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-        .ss-logo-body { padding: 7px; display: flex; justify-content: center; }
-        .ss-logo-body img { width: 58px; height: 58px; }
+        .ss-logo { position: fixed; top: 0; left: 0; margin: 0; will-change: transform; }
 
         /* --- E-INK: a random photo from a photo article, redrawn as a halftone
                mosaic built out of the ShZh logo (ink on background). --- */
@@ -47,22 +47,13 @@
         const reduce = window.matchMedia && matchMedia("(prefers-reduced-motion: reduce)").matches;
 
         if (!eink) {
-            // 25 mini logo.canvas windows caroming off the walls and each other.
+            // 25 real logo.canvas windows caroming off the walls and each other.
+            // We inline the ShZh SVG (exactly like settings.js injectSVG does on the
+            // hub) so the shared `.logo-image-container svg path` rule tints it to the
+            // theme's text colour — an <img> can't be themed and renders black.
             const field = document.getElementById("lcd-field"), N = 25, items = [];
-            for (let i = 0; i < N; i++) {
-                const el = document.createElement("div");
-                el.className = "window ss-logo";
-                el.innerHTML = '<div class="title-bar"><span class="title">❈ logo.canvas</span></div><div class="ss-logo-body"><img src="/logo/shzh.svg" alt=""></div>';
-                field.appendChild(el);
-                const w = el.offsetWidth, h = el.offsetHeight;
-                const sp = reduce ? 0 : 2.4;
-                items.push({ el, w, h,
-                    x: Math.random() * Math.max(1, innerWidth - w),
-                    y: Math.random() * Math.max(1, innerHeight - h),
-                    vx: (Math.random() * 2 - 1) * sp || 1.6, vy: (Math.random() * 2 - 1) * sp || 1.6 });
-                el.style.transform = "translate(" + items[i].x + "px," + items[i].y + "px)";
-            }
-            if (!reduce) (function step() {
+
+            function step() {
                 for (const it of items) {
                     it.x += it.vx; it.y += it.vy;
                     if (it.x <= 0) { it.x = 0; it.vx = Math.abs(it.vx); } else if (it.x + it.w >= innerWidth) { it.x = innerWidth - it.w; it.vx = -Math.abs(it.vx); }
@@ -77,7 +68,29 @@
                 }
                 for (const it of items) it.el.style.transform = "translate(" + it.x.toFixed(1) + "px," + it.y.toFixed(1) + "px)";
                 requestAnimationFrame(step);
-            })();
+            }
+
+            const build = (mark) => {
+                for (let i = 0; i < N; i++) {
+                    const el = document.createElement("div");
+                    el.className = "window ss-logo";
+                    el.innerHTML = '<div class="title-bar"><span class="title" data-key="win_logo_title">❈ logo.canvas</span> <button class="close-btn">&times;</button></div>'
+                        + '<div class="content logo-image-container">' + mark + '</div>';
+                    field.appendChild(el);
+                    const w = el.offsetWidth, h = el.offsetHeight;
+                    const sp = reduce ? 0 : 2.4;
+                    items.push({ el, w, h,
+                        x: Math.random() * Math.max(1, innerWidth - w),
+                        y: Math.random() * Math.max(1, innerHeight - h),
+                        vx: (Math.random() * 2 - 1) * sp || 1.6, vy: (Math.random() * 2 - 1) * sp || 1.6 });
+                    el.style.transform = "translate(" + items[i].x + "px," + items[i].y + "px)";
+                }
+                if (!reduce) requestAnimationFrame(step);
+            };
+
+            fetch("/logo/shzh.svg").then((r) => r.text())
+                .then((svg) => build(svg))
+                .catch(() => build('<img src="/logo/shzh.svg" alt="">'));
         } else {
             // A random photo from a photo article, redrawn as a halftone mosaic of
             // ShZh logos: each cell stamps the logo, sized by how dark the photo is

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 // with the same content hash used for ?v= asset cache-busting, so every deploy
 // that changes an asset also retires the old cache.
 
-const VERSION = '781ca0b6';
+const VERSION = '3bb0d26c';
 const CACHE = `pelmeniboiler-${VERSION}`;
 
 // The minimal shell needed to render pages offline. Everything else (articles,


### PR DESCRIPTION
Follow-up to #15.

## Black-svg bug on the bouncing logos
The LCD screensaver's windows used ``'&lt;img src="/logo/shzh.svg"&gt;'``. An `<img>` can't be recolored by CSS, and `shzh.svg` ships with an internal `.s0 { fill:#000 }`, so the mark stayed **black** — invisible on dark themes.

**Fix:** build each window as the *actual* logo.canvas window — identical markup and classes — with the ShZh SVG **inlined** (exactly what `settings.js` `injectSVG` does on the hub). Now the shared rule `.logo-image-container svg path { fill: var(--text-color) }` tints the logo to the theme's text colour. Verified: white on dark theme, brown on tapuz, etc.

## "Should be identical" to the real logo.canvas
Dropped the custom `.ss-logo` sizing (the small centered logo that made the windows look off). `.ss-logo` now only drives the bounce position; everything else comes from the shared `.window` / `.title-bar` / `.logo-image-container` rules, so the mini windows match the hub's logo.canvas exactly (title bar, close button, 100px mark).

Version bumps `781ca0b6 → 3bb0d26c`. Test suite: **55 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDXeeJN8X7cF8LKYzB54qM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDXeeJN8X7cF8LKYzB54qM)_