### PR TITLE
Never-stale caching, collidable exit window, finer e-ink halftone

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,13 +4,13 @@
     <link id="dynamic-favicon" rel="icon" href="/logo/favicon.svg">
     <link rel="manifest" href="/manifest.json">
     <link rel="preload" href="/styles/fonts/FrankRuhl.ttf" as="font" type="font/ttf" crossorigin>
-    <script src="/scripts/theme-loader.js?v=3bb0d26c"></script>
+    <script src="/scripts/theme-loader.js?v=a43b6c4d"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="translation-source" content="index">
     <meta name="eink-compatibility" content="optimized"> 
     <title>Pelmeniboiler</title>
-    <link rel="stylesheet" href="styles/pelmeni2025.css?v=3bb0d26c">
+    <link rel="stylesheet" href="styles/pelmeni2025.css?v=a43b6c4d">
     <!-- RSS Links for RSS Readers-->
     <link rel="alternate" type="application/rss+xml" title="English RSS Feed" href="https://pelmeniboiler.github.io/rss/en/feed.xml">
     <link rel="alternate" type="application/rss+xml" title="Japanese RSS Feed" href="https://pelmeniboiler.github.io/rss/ja/feed.xml">
@@ -151,10 +151,10 @@
     <div id="settings-module-placeholder"></div>
     <div id="start-menu-module-placeholder"></div>
 
-    <script src="scripts/blog-loader.js?v=3bb0d26c" defer></script>
-    <script src="scripts/module-loader.js?v=3bb0d26c" defer></script>
-    <script src="scripts/notify-bell.js?v=3bb0d26c" defer></script>
-    <script src="scripts/logo-pong.js?v=3bb0d26c" defer></script>
+    <script src="scripts/blog-loader.js?v=a43b6c4d" defer></script>
+    <script src="scripts/module-loader.js?v=a43b6c4d" defer></script>
+    <script src="scripts/notify-bell.js?v=a43b6c4d" defer></script>
+    <script src="scripts/logo-pong.js?v=a43b6c4d" defer></script>
     
 </body>
 </html>

--- a/screensaver/index.html
+++ b/screensaver/index.html
@@ -29,6 +29,11 @@
 
         body.mode-lcd #poster { display: none; }
         body.mode-eink #lcd-field { display: none; }
+        /* In LCD mode the exit prompt is a real window the logos bounce off, so
+           the floating overlay is only used for the e-ink poster. */
+        body.mode-lcd #hint { display: none; }
+        .ss-exit .content { padding: 12px 16px; max-width: 180px; text-align: center;
+            font-family: var(--font-body, serif); color: var(--text-color); line-height: 1.3; }
     </style>
 </head>
 <body>
@@ -53,37 +58,69 @@
             // theme's text colour — an <img> can't be themed and renders black.
             const field = document.getElementById("lcd-field"), N = 25, items = [];
 
+            const place = (el) => {
+                field.appendChild(el);
+                el.style.transform = "translate(" + el._x + "px," + el._y + "px)";
+            };
+
             function step() {
                 for (const it of items) {
+                    if (it.fixed) continue;               // the exit window is an immovable obstacle
                     it.x += it.vx; it.y += it.vy;
                     if (it.x <= 0) { it.x = 0; it.vx = Math.abs(it.vx); } else if (it.x + it.w >= innerWidth) { it.x = innerWidth - it.w; it.vx = -Math.abs(it.vx); }
                     if (it.y <= 0) { it.y = 0; it.vy = Math.abs(it.vy); } else if (it.y + it.h >= innerHeight) { it.y = innerHeight - it.h; it.vy = -Math.abs(it.vy); }
                 }
-                for (let i = 0; i < N; i++) for (let j = i + 1; j < N; j++) {
+                for (let i = 0; i < items.length; i++) for (let j = i + 1; j < items.length; j++) {
                     const a = items[i], b = items[j];
+                    if (a.fixed && b.fixed) continue;
                     if (a.x >= b.x + b.w || a.x + a.w <= b.x || a.y >= b.y + b.h || a.y + a.h <= b.y) continue;
                     const ox = Math.min(a.x + a.w - b.x, b.x + b.w - a.x), oy = Math.min(a.y + a.h - b.y, b.y + b.h - a.y);
-                    if (ox < oy) { const t = a.vx; a.vx = b.vx; b.vx = t; const s = a.x < b.x ? 1 : -1; a.x -= s * ox / 2; b.x += s * ox / 2; }
-                    else { const t = a.vy; a.vy = b.vy; b.vy = t; const s = a.y < b.y ? 1 : -1; a.y -= s * oy / 2; b.y += s * oy / 2; }
+                    if (ox < oy) {
+                        const s = a.x < b.x ? 1 : -1;
+                        if (a.fixed) { b.vx = s < 0 ? Math.abs(b.vx) : -Math.abs(b.vx); b.x += s * ox; }
+                        else if (b.fixed) { a.vx = s < 0 ? -Math.abs(a.vx) : Math.abs(a.vx); a.x -= s * ox; }
+                        else { const t = a.vx; a.vx = b.vx; b.vx = t; a.x -= s * ox / 2; b.x += s * ox / 2; }
+                    } else {
+                        const s = a.y < b.y ? 1 : -1;
+                        if (a.fixed) { b.vy = s < 0 ? Math.abs(b.vy) : -Math.abs(b.vy); b.y += s * oy; }
+                        else if (b.fixed) { a.vy = s < 0 ? -Math.abs(a.vy) : Math.abs(a.vy); a.y -= s * oy; }
+                        else { const t = a.vy; a.vy = b.vy; b.vy = t; a.y -= s * oy / 2; b.y += s * oy / 2; }
+                    }
                 }
-                for (const it of items) it.el.style.transform = "translate(" + it.x.toFixed(1) + "px," + it.y.toFixed(1) + "px)";
+                for (const it of items) if (!it.fixed) it.el.style.transform = "translate(" + it.x.toFixed(1) + "px," + it.y.toFixed(1) + "px)";
                 requestAnimationFrame(step);
             }
 
+            // The exit prompt: a real window, parked in the middle, that the logos
+            // carom off of (immovable obstacle) instead of a floating overlay.
+            const makeExit = () => {
+                const el = document.createElement("div");
+                el.className = "window ss-exit";
+                el.innerHTML = '<div class="title-bar"><span class="title">◈ exit.screensaver</span> <button class="close-btn">&times;</button></div>'
+                    + '<div class="content">click or press any key to exit</div>';
+                el._x = 0; el._y = 0; place(el);
+                const w = el.offsetWidth, h = el.offsetHeight;
+                const x = (innerWidth - w) / 2, y = (innerHeight - h) / 2;
+                el.style.transform = "translate(" + x + "px," + y + "px)";
+                items.push({ el, w, h, x, y, vx: 0, vy: 0, fixed: true });
+            };
+
             const build = (mark) => {
+                makeExit();
                 for (let i = 0; i < N; i++) {
                     const el = document.createElement("div");
                     el.className = "window ss-logo";
                     el.innerHTML = '<div class="title-bar"><span class="title" data-key="win_logo_title">❈ logo.canvas</span> <button class="close-btn">&times;</button></div>'
                         + '<div class="content logo-image-container">' + mark + '</div>';
-                    field.appendChild(el);
+                    el._x = 0; el._y = 0; place(el);
                     const w = el.offsetWidth, h = el.offsetHeight;
                     const sp = reduce ? 0 : 2.4;
-                    items.push({ el, w, h,
+                    const it = { el, w, h,
                         x: Math.random() * Math.max(1, innerWidth - w),
                         y: Math.random() * Math.max(1, innerHeight - h),
-                        vx: (Math.random() * 2 - 1) * sp || 1.6, vy: (Math.random() * 2 - 1) * sp || 1.6 });
-                    el.style.transform = "translate(" + items[i].x + "px," + items[i].y + "px)";
+                        vx: (Math.random() * 2 - 1) * sp || 1.6, vy: (Math.random() * 2 - 1) * sp || 1.6, fixed: false };
+                    items.push(it);
+                    el.style.transform = "translate(" + it.x + "px," + it.y + "px)";
                 }
                 if (!reduce) requestAnimationFrame(step);
             };
@@ -138,7 +175,7 @@
 
             const draw = (im, logo) => {
                 const w = cv.width = innerWidth, h = cv.height = innerHeight;
-                const cell = Math.max(16, Math.round(Math.min(w, h) / 28)); // ~28 logos on the short edge
+                const cell = Math.max(9, Math.round(Math.min(w, h) / 52)); // fine grid: small stamps, more visible halftone
                 const cols = Math.ceil(w / cell), rows = Math.ceil(h / cell);
                 ctx.fillStyle = bg; ctx.fillRect(0, 0, w, h);
                 const lum = sampleGrid(im, cols, rows);

--- a/scripts/theme-loader.js
+++ b/scripts/theme-loader.js
@@ -93,7 +93,13 @@
     // load event so it never competes with rendering the page.
     if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
-            navigator.serviceWorker.register('/sw.js').catch(() => { /* offline support is optional */ });
+            // updateViaCache:'none' — never serve /sw.js itself from the HTTP
+            // cache (GitHub Pages sets max-age=600 on it), so a new worker
+            // version is picked up on the very next visit instead of up to 10
+            // minutes later. Paired with the no-store navigation fetch in sw.js,
+            // this makes stale pages after a deploy essentially impossible.
+            navigator.serviceWorker.register('/sw.js', { updateViaCache: 'none' })
+                .catch(() => { /* offline support is optional */ });
         });
     }
 })();

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 // with the same content hash used for ?v= asset cache-busting, so every deploy
 // that changes an asset also retires the old cache.
 
-const VERSION = '3bb0d26c';
+const VERSION = 'a43b6c4d';
 const CACHE = `pelmeniboiler-${VERSION}`;
 
 // The minimal shell needed to render pages offline. Everything else (articles,
@@ -126,8 +126,13 @@ self.addEventListener('fetch', (event) => {
     if (req.mode === 'navigate') {
         // Pages: network-first so content is always fresh online, with the
         // cached copy as the offline fallback (and the hub as a last resort).
+        // IMPORTANT: cache:'no-store' bypasses the *browser's* HTTP cache.
+        // GitHub Pages serves HTML with max-age=600, so a plain fetch() would
+        // return a page up to 10 minutes stale — exactly why the screensaver
+        // kept showing an old version after a deploy. no-store forces a real
+        // network round-trip; offline still falls back to the cached copy.
         event.respondWith(
-            fetch(req)
+            fetch(req, { cache: 'no-store' })
                 .then((res) => {
                     const copy = res.clone();
                     caches.open(CACHE).then((cache) => cache.put(req, copy));


### PR DESCRIPTION
## Why the "old version" kept coming back — and the permanent fix
This was never a deploy problem (the live files were always correct). It was **browser HTTP caching**, and the service worker wasn't actually bypassing it. GitHub Pages serves both the HTML **and** `sw.js` with `Cache-Control: max-age=600`, so:
- The SW's "network-first" `fetch(req)` happily returned the browser's up-to-10-minute-stale HTML — including the old black-logo screensaver.
- `sw.js` itself was HTTP-cached for 10 min, so the browser didn't even notice a new worker version for that long.

**Fixes:**
1. `sw.js` navigations now use `fetch(req, { cache: 'no-store' })` — a real network round-trip online (offline still falls back to the cached page).
2. Register the worker with `updateViaCache: 'none'` so `/sw.js` is never read from the HTTP cache and new versions are picked up on the next visit.

Together, a stale page after a deploy is essentially impossible going forward. (One-time transition: the *current* stale worker still has to expire once — a single hard-refresh, or ~10 min, gets you onto the new self-updating worker; after that it's automatic forever.)

## Exit prompt is now a collidable window (LCD)
The "click or press any key to exit" text is no longer a floating overlay — in the bouncing-logos mode it's a real `exit.screensaver` window parked in the center that the `logo.canvas` windows carom off. Collision resolution now handles fixed (immovable) vs. moving bodies. The overlay is kept only for the static e-ink poster.

## Finer e-ink halftone
The mosaic grid went from ~28 to ~52 stamps on the short edge, so the ShZh marks are much smaller and the halftone/dither gradation reads far more clearly.

Version bumps to `a43b6c4d`. Test suite: **55 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDXeeJN8X7cF8LKYzB54qM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDXeeJN8X7cF8LKYzB54qM)_