### PR TITLE
Localize motion screensaver + add Plastilin (claymorphism) theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,13 +4,13 @@
     <link id="dynamic-favicon" rel="icon" href="/logo/favicon.svg">
     <link rel="manifest" href="/manifest.json">
     <link rel="preload" href="/styles/fonts/FrankRuhl.ttf" as="font" type="font/ttf" crossorigin>
-    <script src="/scripts/theme-loader.js?v=504305e3"></script>
+    <script src="/scripts/theme-loader.js?v=350f96cf"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="translation-source" content="index">
     <meta name="eink-compatibility" content="optimized"> 
     <title>Pelmeniboiler</title>
-    <link rel="stylesheet" href="styles/pelmeni2025.css?v=504305e3">
+    <link rel="stylesheet" href="styles/pelmeni2025.css?v=350f96cf">
     <!-- RSS Links for RSS Readers-->
     <link rel="alternate" type="application/rss+xml" title="English RSS Feed" href="https://pelmeniboiler.github.io/rss/en/feed.xml">
     <link rel="alternate" type="application/rss+xml" title="Japanese RSS Feed" href="https://pelmeniboiler.github.io/rss/ja/feed.xml">
@@ -151,10 +151,10 @@
     <div id="settings-module-placeholder"></div>
     <div id="start-menu-module-placeholder"></div>
 
-    <script src="scripts/blog-loader.js?v=504305e3" defer></script>
-    <script src="scripts/module-loader.js?v=504305e3" defer></script>
-    <script src="scripts/notify-bell.js?v=504305e3" defer></script>
-    <script src="scripts/logo-pong.js?v=504305e3" defer></script>
+    <script src="scripts/blog-loader.js?v=350f96cf" defer></script>
+    <script src="scripts/module-loader.js?v=350f96cf" defer></script>
+    <script src="scripts/notify-bell.js?v=350f96cf" defer></script>
+    <script src="scripts/logo-pong.js?v=350f96cf" defer></script>
     
 </body>
 </html>

--- a/styles/pelmeni2025.css
+++ b/styles/pelmeni2025.css
@@ -900,6 +900,20 @@ details.inline-details .details-content p:last-child { margin-bottom: 0; }
         inset 8px -8px 14px 0 color-mix(in srgb, var(--text-color) 16%, transparent),
         inset 0 10px 22px 0 rgba(255, 255, 255, 0.8);
 }
+/* Keep content clear of the big rounded corners so nothing clips or crowds. */
+:root.plastilin-mode .content { padding: 20px 24px; }
+:root.plastilin-mode .title-bar { padding: 0 16px; height: 34px; }
+:root.plastilin-mode .title { padding-inline: 2px; }
+/* Each title-bar symbol becomes a little round clay badge. */
+:root.plastilin-mode .title-bar .symbol {
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 1.7em; height: 1.7em; border-radius: 50%; margin-inline-end: 6px;
+    background-color: var(--win-bg-color); color: var(--text-color); font-size: 0.82em;
+    box-shadow:
+        -2px 2px 5px 0 color-mix(in srgb, #000 26%, transparent),
+        inset 2px -2px 4px 0 color-mix(in srgb, #000 20%, transparent),
+        inset 0 2px 4px 0 rgba(255, 255, 255, 0.85);
+}
 
 /* --- NOTIFY BELL (installed-app only; injected by notify-bell.js) --- */
 .notify-dropdown { min-width: 180px; padding: 6px 10px; }

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 // with the same content hash used for ?v= asset cache-busting, so every deploy
 // that changes an asset also retires the old cache.
 
-const VERSION = '504305e3';
+const VERSION = '350f96cf';
 const CACHE = `pelmeniboiler-${VERSION}`;
 
 // The minimal shell needed to render pages offline. Everything else (articles,


### PR DESCRIPTION
Two things that were staged while the GitHub connector was down:

## Motion screensaver localization
The standalone screensaver has no runtime translator, so the build now bakes per-language UI strings into `screensaver/photos.json` (`ui[lang]`): the `logo.canvas` title (reusing `win_logo_title`) plus new `ss_exit_title` / `ss_exit_hint` keys for the exit window. The LCD screensaver shows them in the visitor's language (Hebrew RTL verified), falling back to English.

## Plastilin theme (claymorphism 🫧)
New "Plastilin" (пластилин — plasticine) theme: soft opaque pastel surfaces, no hard borders, big rounded corners, a large soft outer drop-shadow + dark bottom-right & bright top inset shadows for a puffy, inflated 3D clay look. Buttons get the same treatment and press *in* when active. Title-bar symbols each become a little **round clay badge**, and content padding keeps text clear of the rounded corners. Localized (en/he/ru/ja/de), themed cursors.

Version → `350f96cf`. Test suite: **55 passed, 0 failed**; Graflect lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDXeeJN8X7cF8LKYzB54qM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDXeeJN8X7cF8LKYzB54qM)_