### PR TITLE
Prevent colour flashes on e-ink screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,13 +4,13 @@
     <link id="dynamic-favicon" rel="icon" href="/logo/favicon.svg">
     <link rel="manifest" href="/manifest.json">
     <link rel="preload" href="/styles/fonts/FrankRuhl.ttf" as="font" type="font/ttf" crossorigin>
-    <script src="/scripts/theme-loader.js?v=350f96cf"></script>
+    <script src="/scripts/theme-loader.js?v=49bdc249"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="translation-source" content="index">
     <meta name="eink-compatibility" content="optimized"> 
     <title>Pelmeniboiler</title>
-    <link rel="stylesheet" href="styles/pelmeni2025.css?v=350f96cf">
+    <link rel="stylesheet" href="styles/pelmeni2025.css?v=49bdc249">
     <!-- RSS Links for RSS Readers-->
     <link rel="alternate" type="application/rss+xml" title="English RSS Feed" href="https://pelmeniboiler.github.io/rss/en/feed.xml">
     <link rel="alternate" type="application/rss+xml" title="Japanese RSS Feed" href="https://pelmeniboiler.github.io/rss/ja/feed.xml">
@@ -151,10 +151,10 @@
     <div id="settings-module-placeholder"></div>
     <div id="start-menu-module-placeholder"></div>
 
-    <script src="scripts/blog-loader.js?v=350f96cf" defer></script>
-    <script src="scripts/module-loader.js?v=350f96cf" defer></script>
-    <script src="scripts/notify-bell.js?v=350f96cf" defer></script>
-    <script src="scripts/logo-pong.js?v=350f96cf" defer></script>
+    <script src="scripts/blog-loader.js?v=49bdc249" defer></script>
+    <script src="scripts/module-loader.js?v=49bdc249" defer></script>
+    <script src="scripts/notify-bell.js?v=49bdc249" defer></script>
+    <script src="scripts/logo-pong.js?v=49bdc249" defer></script>
     
 </body>
 </html>

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -252,10 +252,21 @@ function setupSettings() {
         galleryCurrentSrc = null;
 
     const galleryRGB = (s) => (s.match(/\d+/g) || [0, 0, 0]).map(Number).slice(0, 3);
+    // Read the theme's *target* ink/paper via a throwaway element, so a running
+    // background-color/color transition can't hand us a mid-fade (tinted) colour
+    // — that was what let the previous theme's colours bleed into the e-ink dither.
+    function themeInkPaper() {
+        const probe = document.createElement('span');
+        probe.style.cssText = 'position:absolute;left:-9999px;visibility:hidden;transition:none;color:var(--text-color);background-color:var(--bg-color)';
+        body.appendChild(probe);
+        const pcs = getComputedStyle(probe);
+        const ink = galleryRGB(pcs.color), paper = galleryRGB(pcs.backgroundColor);
+        probe.remove();
+        return { ink, paper };
+    }
     // Dither one image to the theme's ink/paper and return it as a data URL.
     function galleryDither(img) {
-        const cs = getComputedStyle(body);
-        const ink = galleryRGB(cs.color), paper = galleryRGB(cs.backgroundColor);
+        const { ink, paper } = themeInkPaper();
         const w = window.innerWidth, h = window.innerHeight;
         const cv = document.createElement('canvas'); cv.width = w; cv.height = h;
         const ctx = cv.getContext('2d', { willReadFrequently: true });
@@ -294,6 +305,9 @@ function setupSettings() {
         clearInterval(galleryTimer); galleryTimer = null;
         if (!galleryPhotos.length) return;
         if (docEl.classList.contains('eink-mode')) {
+            // Blank the layers first so no leftover colour photo flashes while the
+            // dithered still is being computed; #gallery-bg's own bg (paper) shows.
+            galleryLayers.forEach((l) => { l.style.opacity = '0'; l.style.backgroundImage = 'none'; });
             // One random photo, dithered, no motion, no colour.
             const p = galleryPhotos[Math.floor(Math.random() * galleryPhotos.length)];
             const img = new Image();

--- a/styles/pelmeni2025.css
+++ b/styles/pelmeni2025.css
@@ -134,8 +134,9 @@ body {
     font-family: var(--font-body);
     margin: 0; padding: 0; line-height: 1.5;
     transition: background-color 0.3s ease, color 0.3s ease;
-    padding-bottom: 40px; 
+    padding-bottom: 40px;
     overflow: hidden;
+
     color: var(--text-color); 
     background-color: var(--bg-color);
 }
@@ -378,6 +379,9 @@ body.gallery-mode #gallery-bg { display: block; }
     background-size: cover; background-position: center; transition: opacity 1.4s ease; }
 /* E-ink gallery is a single dithered still — no cross-fade, crisp dither dots. */
 body.eink-mode #gallery-bg .gallery-layer { transition: none; image-rendering: pixelated; }
+/* E-ink must never animate a colour → snap instantly, no fade through the old
+   theme's colours (which would otherwise tint the gallery dither on entry). */
+body.eink-mode, body.eink-mode * { transition: none !important; }
 h1, h2, h3, h4, h5, h6 { margin: 0 0 0.6em 0; padding: 0; font-weight: bold; }
 p { font-size: 14px; margin-bottom: 0.8em; }
 .content { padding: 10px; overflow-y: auto; max-height: 350px; flex-grow: 1; min-height: 0; }

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 // with the same content hash used for ?v= asset cache-busting, so every deploy
 // that changes an asset also retires the old cache.
 
-const VERSION = '350f96cf';
+const VERSION = '49bdc249';
 const CACHE = `pelmeniboiler-${VERSION}`;
 
 // The minimal shell needed to render pages offline. Everything else (articles,


### PR DESCRIPTION
Fixes the quirk where entering e-ink with gallery mode on tinted the dither with the previous theme's colours — and hardens e-ink against colour flashes generally.

- The gallery dither read `body`'s **live** computed colour while the 0.3s `background-color`/`color` transition was still animating, so a mid-fade (tinted) colour leaked into the dither. It now reads the **target** ink/paper via a throwaway, transition-free probe element.
- Entering e-ink from a colour theme animated the desktop colours through a visible fade. E-ink now disables transitions entirely (`body.eink-mode * { transition: none !important }`) so colours snap.
- The gallery layers are blanked before the dithered still is computed, so no leftover colour photo flashes in the meantime.

Verified: toggling into e-ink from Tapuz (orange) with gallery on yields **0 coloured pixels** in the dither. Test suite: **55 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDXeeJN8X7cF8LKYzB54qM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDXeeJN8X7cF8LKYzB54qM)_