### PR TITLE
Pad title bars in from the edges on rounded-corner themes

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,13 +4,13 @@
     <link id="dynamic-favicon" rel="icon" href="/logo/favicon.svg">
     <link rel="manifest" href="/manifest.json">
     <link rel="preload" href="/styles/fonts/FrankRuhl.ttf" as="font" type="font/ttf" crossorigin>
-    <script src="/scripts/theme-loader.js?v=649555e9"></script>
+    <script src="/scripts/theme-loader.js?v=848e2384"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="translation-source" content="index">
     <meta name="eink-compatibility" content="optimized"> 
     <title>Pelmeniboiler</title>
-    <link rel="stylesheet" href="styles/pelmeni2025.css?v=649555e9">
+    <link rel="stylesheet" href="styles/pelmeni2025.css?v=848e2384">
     <!-- RSS Links for RSS Readers-->
     <link rel="alternate" type="application/rss+xml" title="English RSS Feed" href="https://pelmeniboiler.github.io/rss/en/feed.xml">
     <link rel="alternate" type="application/rss+xml" title="Japanese RSS Feed" href="https://pelmeniboiler.github.io/rss/ja/feed.xml">
@@ -151,10 +151,10 @@
     <div id="settings-module-placeholder"></div>
     <div id="start-menu-module-placeholder"></div>
 
-    <script src="scripts/blog-loader.js?v=649555e9" defer></script>
-    <script src="scripts/module-loader.js?v=649555e9" defer></script>
-    <script src="scripts/notify-bell.js?v=649555e9" defer></script>
-    <script src="scripts/logo-pong.js?v=649555e9" defer></script>
+    <script src="scripts/blog-loader.js?v=848e2384" defer></script>
+    <script src="scripts/module-loader.js?v=848e2384" defer></script>
+    <script src="scripts/notify-bell.js?v=848e2384" defer></script>
+    <script src="scripts/logo-pong.js?v=848e2384" defer></script>
     
 </body>
 </html>

--- a/styles/pelmeni2025.css
+++ b/styles/pelmeni2025.css
@@ -1022,6 +1022,8 @@ details.inline-details .details-content p:last-child { margin-bottom: 0; }
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 :root.glass-mode .title { color: var(--text-color); }
+/* Curved corners eat the very edge, so pad the title bar in from the sides. */
+:root.glass-mode .title-bar, :root.y2k-mode .title-bar { padding-inline: 18px; }
 :root.glass-mode .close-btn,
 :root.glass-mode .filter-btn,
 :root.glass-mode .normal-btn,

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 // with the same content hash used for ?v= asset cache-busting, so every deploy
 // that changes an asset also retires the old cache.
 
-const VERSION = '649555e9';
+const VERSION = '848e2384';
 const CACHE = `pelmeniboiler-${VERSION}`;
 
 // The minimal shell needed to render pages offline. Everything else (articles,


### PR DESCRIPTION
Curved corners were crowding the title text on Liquid Glass and Y2K — added horizontal title-bar padding so titles sit clear of the radius. (Plastilin already had it.) Version → `848e2384`, 55/55 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDXeeJN8X7cF8LKYzB54qM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDXeeJN8X7cF8LKYzB54qM)_