### PR TITLE
Keep FairfaxHD in WordArt & Win98 font stacks (fixes Graflect)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,13 +4,13 @@
     <link id="dynamic-favicon" rel="icon" href="/logo/favicon.svg">
     <link rel="manifest" href="/manifest.json">
     <link rel="preload" href="/styles/fonts/FrankRuhl.ttf" as="font" type="font/ttf" crossorigin>
-    <script src="/scripts/theme-loader.js?v=beb80dfc"></script>
+    <script src="/scripts/theme-loader.js?v=28ba47c8"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="translation-source" content="index">
     <meta name="eink-compatibility" content="optimized"> 
     <title>Pelmeniboiler</title>
-    <link rel="stylesheet" href="styles/pelmeni2025.css?v=beb80dfc">
+    <link rel="stylesheet" href="styles/pelmeni2025.css?v=28ba47c8">
     <!-- RSS Links for RSS Readers-->
     <link rel="alternate" type="application/rss+xml" title="English RSS Feed" href="https://pelmeniboiler.github.io/rss/en/feed.xml">
     <link rel="alternate" type="application/rss+xml" title="Japanese RSS Feed" href="https://pelmeniboiler.github.io/rss/ja/feed.xml">
@@ -151,10 +151,10 @@
     <div id="settings-module-placeholder"></div>
     <div id="start-menu-module-placeholder"></div>
 
-    <script src="scripts/blog-loader.js?v=beb80dfc" defer></script>
-    <script src="scripts/module-loader.js?v=beb80dfc" defer></script>
-    <script src="scripts/notify-bell.js?v=beb80dfc" defer></script>
-    <script src="scripts/logo-pong.js?v=beb80dfc" defer></script>
+    <script src="scripts/blog-loader.js?v=28ba47c8" defer></script>
+    <script src="scripts/module-loader.js?v=28ba47c8" defer></script>
+    <script src="scripts/notify-bell.js?v=28ba47c8" defer></script>
+    <script src="scripts/logo-pong.js?v=28ba47c8" defer></script>
     
 </body>
 </html>

--- a/styles/pelmeni2025.css
+++ b/styles/pelmeni2025.css
@@ -133,7 +133,7 @@
    the actual desktop --bg-color is teal.) */
 :root.win98-mode {
     --theme-bg-color: #C0C0C0; --theme-text-color: #000000; --theme-border-color: #808080; --theme-accent-color: #000080;
-    --font-body: Tahoma, Verdana, Geneva, 'MS Sans Serif', sans-serif;
+    --font-body: Tahoma, Verdana, Geneva, 'MS Sans Serif', sans-serif, 'FairfaxHD';
     --bg-color: #008080; --win-bg-color: #C0C0C0; --text-color: #000000; --border-color: #808080; --inv-bg-color: #000080; --inv-text-color: #FFFFFF; --link-hover-bg: #000080; --link-hover-color: #FFFFFF;
 }
 /* Glass: liquid-glass — translucent panes that refract what's behind. Best over
@@ -151,7 +151,7 @@
    text, garish window borders. Abandon all taste. */
 :root.wordart-mode {
     --theme-bg-color: #14B8C4; --theme-text-color: #2A0A4A; --theme-border-color: #8E44AD; --theme-accent-color: #FFE400;
-    --font-body: 'Comic Sans MS', 'Comic Sans', 'Chalkboard SE', cursive;
+    --font-body: 'Comic Sans MS', 'Comic Sans', 'Chalkboard SE', cursive, 'FairfaxHD';
     --bg-color: #14B8C4; --win-bg-color: #FFFFFF; --text-color: #2A0A4A; --border-color: #8E44AD; --inv-bg-color: #8E44AD; --inv-text-color: #FFE400; --link-hover-bg: #FFE400; --link-hover-color: #C0392B;
 }
 
@@ -1110,7 +1110,7 @@ details.inline-details .details-content p:last-child { margin-bottom: 0; }
 :root.wordart-mode h1, :root.wordart-mode h2, :root.wordart-mode h3,
 :root.wordart-mode .blog-post h3 a,
 :root.wordart-mode .welcome-text-lcd, :root.wordart-mode .welcome-text-eink b {
-    font-family: Impact, 'Haettenschweiler', 'Arial Narrow Bold', 'Franklin Gothic Bold', sans-serif;
+    font-family: Impact, 'Haettenschweiler', 'Arial Narrow Bold', 'Franklin Gothic Bold', sans-serif, 'FairfaxHD';
     font-weight: 900; letter-spacing: 1px;
     background: linear-gradient(92deg, #ff2d55, #ff9500, #ffcc00, #34c759, #00c7ff, #af52de, #ff2d55);
     -webkit-background-clip: text; background-clip: text;

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 // with the same content hash used for ?v= asset cache-busting, so every deploy
 // that changes an asset also retires the old cache.
 
-const VERSION = 'beb80dfc';
+const VERSION = '28ba47c8';
 const CACHE = `pelmeniboiler-${VERSION}`;
 
 // The minimal shell needed to render pages offline. Everything else (articles,


### PR DESCRIPTION
Both WordArt and Windows 98 overrode `--font-body` (and WordArt's Impact heading font) **without** the `FairfaxHD` fallback, so Graflect's PUA glyphs rendered as tofu. Appended `'FairfaxHD'` to those three stacks so `gt` renders — even styled as rainbow WordArt.

Verified: Graflect renders correctly in both themes (checked computed font-family + screenshot). 55/55 tests, Graflect lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDXeeJN8X7cF8LKYzB54qM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDXeeJN8X7cF8LKYzB54qM)_