### PR TITLE
Fix settings + about windows on phones

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,13 +4,13 @@
     <link id="dynamic-favicon" rel="icon" href="/logo/favicon.svg">
     <link rel="manifest" href="/manifest.json">
     <link rel="preload" href="/styles/fonts/FrankRuhl.ttf" as="font" type="font/ttf" crossorigin>
-    <script src="/scripts/theme-loader.js?v=28ba47c8"></script>
+    <script src="/scripts/theme-loader.js?v=f16d8d2c"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="translation-source" content="index">
     <meta name="eink-compatibility" content="optimized"> 
     <title>Pelmeniboiler</title>
-    <link rel="stylesheet" href="styles/pelmeni2025.css?v=28ba47c8">
+    <link rel="stylesheet" href="styles/pelmeni2025.css?v=f16d8d2c">
     <!-- RSS Links for RSS Readers-->
     <link rel="alternate" type="application/rss+xml" title="English RSS Feed" href="https://pelmeniboiler.github.io/rss/en/feed.xml">
     <link rel="alternate" type="application/rss+xml" title="Japanese RSS Feed" href="https://pelmeniboiler.github.io/rss/ja/feed.xml">
@@ -151,10 +151,10 @@
     <div id="settings-module-placeholder"></div>
     <div id="start-menu-module-placeholder"></div>
 
-    <script src="scripts/blog-loader.js?v=28ba47c8" defer></script>
-    <script src="scripts/module-loader.js?v=28ba47c8" defer></script>
-    <script src="scripts/notify-bell.js?v=28ba47c8" defer></script>
-    <script src="scripts/logo-pong.js?v=28ba47c8" defer></script>
+    <script src="scripts/blog-loader.js?v=f16d8d2c" defer></script>
+    <script src="scripts/module-loader.js?v=f16d8d2c" defer></script>
+    <script src="scripts/notify-bell.js?v=f16d8d2c" defer></script>
+    <script src="scripts/logo-pong.js?v=f16d8d2c" defer></script>
     
 </body>
 </html>

--- a/styles/pelmeni2025.css
+++ b/styles/pelmeni2025.css
@@ -568,12 +568,20 @@ textarea::-webkit-scrollbar-thumb {
     }
     .window {
         position: relative;
-        width: auto;
+        /* !important so windows with an inline width (settings, folder indexes)
+           still stretch full-width instead of staying half-off the screen. */
+        width: auto !important;
+        max-width: none !important;
+        box-sizing: border-box;
         left: 0 !important;
         top: 0 !important;
         margin: 10px;
         z-index: auto !important;
     }
+    /* Long single-line content (e.g. the about name) must wrap on a phone rather
+       than force a sideways scroll. */
+    .window .content { overflow-x: hidden; }
+    #about-window .content h2 { white-space: normal; overflow-wrap: break-word; }
     .title-bar { cursor: var(--cur-default); }
     .start-menu {
         width: 100%;

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
 // with the same content hash used for ?v= asset cache-busting, so every deploy
 // that changes an asset also retires the old cache.
 
-const VERSION = '28ba47c8';
+const VERSION = 'f16d8d2c';
 const CACHE = `pelmeniboiler-${VERSION}`;
 
 // The minimal shell needed to render pages offline. Everything else (articles,


### PR DESCRIPTION
Two mobile (≤768px) layout fixes:

- **Settings window (and folder-index windows) were half-width.** They carry an inline `width` (e.g. `50%`), which beat the mobile stylesheet's `width: auto`. Now `width: auto !important; max-width: none !important` so they stretch full width. (Measured: settings 199px → 370px on a 390px viewport.)
- **The about window scrolled sideways.** `#about-window .content h2` is intentionally `white-space: nowrap` on desktop (keeps the name on one line), but on a phone the name overflowed. It now wraps on phones (`white-space: normal; overflow-wrap: break-word`), plus `overflow-x: hidden` on `.content` as a safety net. (Content scroll-width now equals client-width — no horizontal scroll.)

Verified at 390px with device emulation; screenshots confirm both. 55/55 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDXeeJN8X7cF8LKYzB54qM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDXeeJN8X7cF8LKYzB54qM)_